### PR TITLE
Replace 'None' with 'null' values in parameters

### DIFF
--- a/check_point_mgmt/check_point_mgmt.py
+++ b/check_point_mgmt/check_point_mgmt.py
@@ -125,6 +125,7 @@ def main():
     session_data = module.params.get("session-data")
     fingerprint = module.params.get("fingerprint")
     if parameters:
+	    parameters = parameters.replace("None", "null")
         parameters = json.loads(parameters.replace("'", '"'))
     if command == "login":
         # Login parameters:


### PR DESCRIPTION
As an hygienic measure, replace all null values in Ansible format (i.e. "None" values) with "null" values, that Python understands.