### PR TITLE
Synchronize package change with cp-checkpoing-mgmt-sdk path change

### DIFF
--- a/check_point_mgmt/check_point_mgmt.py
+++ b/check_point_mgmt/check_point_mgmt.py
@@ -5,7 +5,7 @@ import sys
 
 from ansible.module_utils.basic import AnsibleModule
 
-from cp_mgmt_api_python_sdk.lib import APIClient, APIClientArgs
+from cp_mgmt_api_python_sdk import APIClient, APIClientArgs
 
 # arguments for the module:
 fields = {


### PR DESCRIPTION
The change made in https://github.com/CheckPointSW/cp_mgmt_api_python_sdk/pull/3, will break Ansible module. This PR corrects that situation.